### PR TITLE
Allow playbooks to run using ansible-runner from automate

### DIFF
--- a/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
+++ b/app/models/manageiq/providers/embedded_ansible/automation_manager/playbook_runner.rb
@@ -166,6 +166,7 @@ class ManageIQ::Providers::EmbeddedAnsible::AutomationManager::PlaybookRunner < 
     ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ConfigurationScript.new(
       :manager     => playbook.manager,
       :manager_ref => options[:job_template_ref],
+      :parent_id   => playbook.id,
       :variables   => {}
     )
   end


### PR DESCRIPTION
We need the parent playbook id in order to find the filesystem
path for the playbook later on.